### PR TITLE
Improvements and Adherence to *LFS standards

### DIFF
--- a/appendices/mit-glfs.xml
+++ b/appendices/mit-glfs.xml
@@ -5,8 +5,8 @@
   %general-entities;
 ]>
 
-<appendix id="MIT" xreflabel="MIT License">
-  <?dbhtml filename="mit.html" ?>
+<appendix id="MIT-GLFS" xreflabel="MIT License (GLFS)">
+  <?dbhtml filename="mit-glfs.html" ?>
 
   <appendixinfo>
     <date>$Date$</date>

--- a/appendices/mit-glfs.xml
+++ b/appendices/mit-glfs.xml
@@ -15,7 +15,7 @@
   <title>The MIT License</title>
 
   <para>
-    Copyright &copy; &copyrightdate; BLFS Development Team;
+    Copyright &copy; &copyrightdate; &copyholder;
   </para>
 
   <para>

--- a/changelog.xml
+++ b/changelog.xml
@@ -1,0 +1,1 @@
+introduction/welcome/changelog.xml

--- a/index.xml
+++ b/index.xml
@@ -23,6 +23,7 @@ $Date$
   <!-- Appendices -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="appendices/creat-comm.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="appendices/mit-lic.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="appendices/mit-glfs.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="appendices/glossary.xml"/>
 
 </book>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY changelogs  "https://www.linuxfromscratch.org/blfs">
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+]>
+
+<!-- vim: set expandtab: -->
+
+<sect1 id="changelog" xreflabel="Change Log">
+  <?dbhtml filename="changelog.html"?>
+
+
+  <title>Change Log</title>
+
+  <!-- <para>Please note that the Change Log only lists which editor was
+  responsible for putting the changes into SVN; please read the
+  <xref linkend="credits"/> page in Chapter 1 for details on
+  who wrote what.</para> -->
+
+  <para>Current release: &version; &ndash; &releasedate;</para>
+
+  <itemizedlist>
+    <title>Changelog Entries:</title>
+
+<!-- Changelog template
+    <listitem>
+      <para>MMMM DD{nd,st,th}, YYYY</para>
+      <itemizedlist>
+        <listitem>
+          <para>[name] - Changelog entry.</para>
+        </listitem>
+        <listitem>
+          <para>[name] - Another changelog entry.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+    -->
+
+     <listitem>
+      <para>May 23rd, 2024</para>
+      <itemizedlist>
+        <listitem>
+          <para>[tester] - Create Changelog. Fixes</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+
+  </itemizedlist>
+</sect1>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,7 +43,7 @@
       <para>May 23rd, 2024</para>
       <itemizedlist>
         <listitem>
-          <para>[tester] - Create Changelog. Fixes</para>
+          <para>[tester] - Create Changelog.</para>
         </listitem>
       </itemizedlist>
     </listitem>

--- a/introduction/welcome/welcome.xml
+++ b/introduction/welcome/welcome.xml
@@ -31,6 +31,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="which.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="conventions.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="packages.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="changelog.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="rationale.xml"/>
   <!--   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="newsserver.xml"/> -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="askhelp.xml"/>

--- a/multilib/whatisml.xml
+++ b/multilib/whatisml.xml
@@ -36,10 +36,10 @@
 
     <note>
 	<para>
-	It is worth nothing that when covering multilib, we mean
-	emulation of 32-bit software on a 64-bit CPU and this
-	is the case for most users nowadays, but the future is heading
-	towards ARM64 slowly. We will not be covering ARM at this time.
+	It is worth noting that when the term multilib is used throughout
+	this book, it is referring to running i686 instructions on an x86_64
+	host.  This does not cover running other 32 bit architectures on their
+	64 bit extensions, like armhf on arm64.
 	</para>
     </note>
 

--- a/wine/wine/wine.xml
+++ b/wine/wine/wine.xml
@@ -27,7 +27,7 @@
     <title>Introduction to Wine</title>
 
     <para>
-	Wine Is Not Emulation.
+	Wine Is Not an Emulator.
     </para>
 
     &lfs121_checked;


### PR DESCRIPTION
This pull fixes the following
1) Licensing issue, the MIT License from the original BLFS code must be included, this adds it and essentially makes GLFS sublicensed instead of relicensing BLFS.
2) Typos
3) Adds back changelog.xml to adhere to *LFS standards
4) Fixes Wine acronym.