### PR TITLE
Mesa and HarfBuzz

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -152,7 +152,7 @@
 <!ENTITY yaml-version                 "0.2.5">
 <!ENTITY pyyaml-version               "6.0.2">
 <!ENTITY mesa-major-minor             "24.2">
-<!ENTITY mesa-version                 "&mesa-major-minor;.3">
+<!ENTITY mesa-version                 "&mesa-major-minor;.4">
 <!-- X11 -->
 <!ENTITY xcb-util-version             "0.4.1">
 <!ENTITY xcb-util-image-version       "0.4.1">

--- a/shareddeps/dps/basicx/other/harfbuzz.xml
+++ b/shareddeps/dps/basicx/other/harfbuzz.xml
@@ -96,6 +96,14 @@
       </para>
     </important>
 
+    <note>
+      <para>
+        If you want to build Pango, HarfBuzz must be built with Glib support.
+        Instructions for doing so may be found on
+        <ulink url="&blfs-svn;/general/harfbuzz.html">BLFS's HarfBuzz page</ulink>.
+      </para>
+    </note>
+
     <para>
       Install <application>HarfBuzz</application> by running the following
       commands:


### PR DESCRIPTION
Hi Zeckma, I don't use Git enough to know how to PR properly, but I'm trying to figure it out. So bear that in mind :)

I updated Mesa's version in packages.ent to 24.2.4. It built fine in my testing.

I added a note to the HarfBuzz page about Pango. I felt it necessary since I spent about 2 hours not realizing Pango needed HarfBuzz to be compiled with Glib support some weeks ago.

Feel free to DM me on Discord if you'd like to reach me (@toxikuu)