### PR TITLE
libunwind 1.6.2 -> 1.8.1 (and tweaks)

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -92,7 +92,7 @@
 <!ENTITY cmake-version                "&cmake-major-version;.&cmake-minor-version;">
 <!-- extra-cmake-modules version is the same as kf6-frameworks -->
 <!ENTITY dbus-version                 "1.14.10">   <!-- Even minors only -->
-<!ENTITY libunwind-version            "1.6.2">
+<!ENTITY libunwind-version            "1.8.1">
 <!ENTITY nettle-version               "3.10">
 <!ENTITY gnutls-version               "3.8.7.1">
 <!-- The line below has two extra spaces at the end in BLFS, matching it here. -->

--- a/shareddeps/dps/basicx/other/libunwind.xml
+++ b/shareddeps/dps/basicx/other/libunwind.xml
@@ -4,7 +4,7 @@
   <!ENTITY % general-entities SYSTEM "../../../../general.ent">
   %general-entities;
 
-  <!ENTITY libunwind-download-http "https://download.savannah.nongnu.org/releases/libunwind/libunwind-&libunwind-version;.tar.gz">
+  <!ENTITY libunwind-download-http "https://github.com/libunwind/libunwind/releases/download/v&libunwind-version;/libunwind-&libunwind-version;.tar.gz">
   <!ENTITY libunwind-download-ftp  " ">
 ]>
 
@@ -58,9 +58,9 @@
 make</userinput></screen>
 
     <para>
-      To test the results, issue: <command>make check</command>.  Two
-      tests, run-coredump-unwind and run-coredump-unwind-mdi are known
-      to fail.
+      To test the results, issue: <command>make check</command>. 
+      Two tests, run-coredump-unwind and run-coredump-unwind-mdi, are 
+      skipped.
     </para>
 
     <para>
@@ -78,7 +78,7 @@ make</userinput></screen>
       First clean the directory:
     </para>
 
-    <screen><userinput>make clean &amp;&amp; rm -f Makefile</userinput></screen>
+    <screen><userinput>make clean</userinput></screen>
 
     <para>
       Install lib32-<application>libunwind</application> by running the following


### PR DESCRIPTION
Hi Zeckma,

I noticed libunwind is outdated. It built fine with the new version and passed 36/38 tests (skipping two instead of failing). I adjusted the (unsupported past 1.6.2) download link; it is now libunwind's Github instead of nongnu. Also, I tested just running make clean, and the 32-bit libunwind now builds fine without deleting the makefile.