### PR TITLE
disabled tests and added libxslt as an optional dependency

### DIFF
--- a/shareddeps/security/glib2.xml
+++ b/shareddeps/security/glib2.xml
@@ -74,9 +74,14 @@
     </para>
 
     <bridgehead renderas="sect4">Recommended</bridgehead>
-    <para role="required">
+    <para role="recommended">
       <xref linkend="pcre2"/> (if not built, Meson will try to fetch a tarball
       of PCRE2 source code from the internet)
+  </para>
+
+    <bridgehead renderas="sect4">Optional</bridgehead>
+    <para role="optional">
+      <ulink url="&blfs-svn;/general/libxslt.html">libxslt</ulink> (for man-pages)
     </para>
 
     <bridgehead renderas="sect4">Additional Runtime Dependencies</bridgehead>
@@ -142,6 +147,7 @@ meson setup ..                  \
       -D introspection=disabled \
       -D glib_debug=disabled    \
       -D man-pages=disabled     \
+      -D tests=disabled         \
       -D sysprof=disabled       &amp;&amp;
 
 ninja</userinput></screen>
@@ -209,6 +215,7 @@ ninja</userinput></screen>
       -D introspection=disabled \
       -D glib_debug=disabled    \
       -D man-pages=disabled     \
+      -D tests=disabled         \
       -D sysprof=disabled       &amp;&amp;
 
 ninja</userinput></screen>
@@ -233,6 +240,14 @@ ldconfig</userinput></screen>
     <para>
       <parameter>-D man-pages=disabled</parameter>: This switch causes the
       build to create and install the package man pages.
+    </para>
+
+    <para>
+      <parameter>-D tests=disabled</parameter>: This switch causes tests
+      to be built. It is disabled because it is beyond the scope of GLFS.
+      If you'd like to test glib, reference
+      <ulink url="https://www.linuxfromscratch.org/blfs/view/svn/general/glib2.html">
+      BLFS's glib page</ulink>.
     </para>
 
     <para>


### PR DESCRIPTION
Hello, I added an option to disable the glib tests as they're built by default, but GLFS doesn't provide instructions for running them. I also added an explanation for it.

I've also added libxslt as an optional dependency for man-pages.

Additionally, I changed the role for pcre2 from required to recommended. (I think this was a typo, but I may be mistaken.)