### PR TITLE
NSS + SQLite Build Fix

### DIFF
--- a/shareddeps/net/nss.xml
+++ b/shareddeps/net/nss.xml
@@ -99,6 +99,24 @@
 patch -Np1 -i ../nss-&nss-version;-illegal_instruction-1.patch</userinput></screen>
 
 -->
+
+    <important>
+      <para>
+        If you're rebuilding NSS and you have not installed SQLite, run the
+        following command to prevent a build failure:
+      </para>
+
+<screen role="root"><userinput remap="pre">sqlite3 --version > /dev/null 2>&amp;1 &amp;&amp; echo -e "\nDetected an SQLite install. You may continue." || 
+if [ -f /usr/lib/libsqlite3.so -o -f /usr/lib32/libsqlite3.so ]; then
+  echo -e "\nDetected an incomplete SQLite installation!" >&amp;2
+  rm -vf /usr/lib{,32}/libsqlite3.so
+  echo "Removed any problematic SQLite libraries. You may continue."
+else
+  echo -e "\nNo SQLite install (complete or otherwise) detected. You may continue."
+fi</userinput></screen>
+
+    </important>
+
     <para>
       Install <application>NSS</application> by running the following commands:
     </para>

--- a/shareddeps/security/glib2.xml
+++ b/shareddeps/security/glib2.xml
@@ -74,9 +74,14 @@
     </para>
 
     <bridgehead renderas="sect4">Recommended</bridgehead>
-    <para role="required">
+    <para role="recommended">
       <xref linkend="pcre2"/> (if not built, Meson will try to fetch a tarball
       of PCRE2 source code from the internet)
+  </para>
+
+    <bridgehead renderas="sect4">Optional</bridgehead>
+    <para role="optional">
+      <ulink url="&blfs-svn;/general/libxslt.html">libxslt</ulink> (for man-pages)
     </para>
 
     <bridgehead renderas="sect4">Additional Runtime Dependencies</bridgehead>
@@ -142,6 +147,7 @@ meson setup ..                  \
       -D introspection=disabled \
       -D glib_debug=disabled    \
       -D man-pages=disabled     \
+      -D tests=disabled         \
       -D sysprof=disabled       &amp;&amp;
 
 ninja</userinput></screen>
@@ -209,6 +215,7 @@ ninja</userinput></screen>
       -D introspection=disabled \
       -D glib_debug=disabled    \
       -D man-pages=disabled     \
+      -D tests=disabled         \
       -D sysprof=disabled       &amp;&amp;
 
 ninja</userinput></screen>
@@ -233,6 +240,14 @@ ldconfig</userinput></screen>
     <para>
       <parameter>-D man-pages=disabled</parameter>: This switch causes the
       build to create and install the package man pages.
+    </para>
+
+    <para>
+      <parameter>-D tests=disabled</parameter>: This switch causes tests
+      to be built. It is disabled because it is beyond the scope of GLFS.
+      If you'd like to test glib, reference
+      <ulink url="https://www.linuxfromscratch.org/blfs/view/svn/general/glib2.html">
+      BLFS's glib page</ulink>.
     </para>
 
     <para>


### PR DESCRIPTION
Hi, I added a command to check whether an incomplete SQLite install exists, and remove two problematic libraries if it does. These two libraries break the rebuilding of NSS if SQLite is missing. Feel free to adjust it; I made it more verbose than it had to be for clarity, but you can trim it down if you like :)

Also I forgot to clean up from the glib commit, so that's here still. Oops.